### PR TITLE
Add simple xslt stylesheet to extract ssml from news articles

### DIFF
--- a/any-to-ssml.sh
+++ b/any-to-ssml.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+echo "${#}"
+
+if [ "$#" -ne "1" ]; then
+    echo "Usage: ${0} URL"
+else
+    curl "${1}" | xsltproc --html any-to-ssml.xslt - 2>/dev/null
+fi

--- a/any-to-ssml.sh
+++ b/any-to-ssml.sh
@@ -2,8 +2,6 @@
 
 set -eu
 
-echo "${#}"
-
 if [ "$#" -ne "1" ]; then
     echo "Usage: ${0} URL"
 else

--- a/any-to-ssml.xslt
+++ b/any-to-ssml.xslt
@@ -1,0 +1,64 @@
+<xsl:stylesheet
+    version="1.0"
+    xmlns="https://www.w3.org/2001/10/synthesis"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+>
+
+    <!-- entry point, look for <article> -->
+    <xsl:template match="/">
+        <speak xml:lang="de-DE">
+            <xsl:apply-templates select="//article"/>
+        </speak>
+    </xsl:template>
+
+    <xsl:template match="//article">
+        <xsl:apply-templates select="*|text()" mode="block"/>
+    </xsl:template>
+
+    <!-- templates for block elements -->
+    <xsl:template match="h1|h2|h3|h4|h5|h6" mode="block">
+        <p>
+            <xsl:apply-templates select="*|text()" mode="inline"/>
+        </p>
+    </xsl:template>
+
+    <xsl:template match="p" mode="block">
+        <p>
+            <xsl:apply-templates select="*|text()" mode="inline"/>
+        </p>
+    </xsl:template>
+
+    <xsl:template match="*" mode="block">
+        <xsl:apply-templates select="*|text()" mode="block"/>
+    </xsl:template>
+
+    <xsl:template match="text()" mode="block">
+        <xsl:apply-templates select="*|text()" mode="inline"/>
+    </xsl:template>
+
+    <!-- templates for inline elements -->
+    <xsl:template match="i|em|strong|bold" mode="inline">
+        <emphasis>
+            <xsl:apply-templates select="*|text()" mode="inline"/>
+        </emphasis>
+    </xsl:template>
+
+    <xsl:template match="a" mode="inline">
+        <xsl:text>(Link Start)</xsl:text>
+        <xsl:apply-templates select="*|text()" mode="inline"/>
+        <xsl:text>(Link Ende)</xsl:text>
+    </xsl:template>
+
+    <xsl:template match="*" mode="inline">
+        <xsl:apply-templates select="*|text()" mode="inline"/>
+        <!-- additional whitespace to cover case when inline element is followed by raw text -->
+        <xsl:text> </xsl:text>
+    </xsl:template>
+
+    <xsl:template match="text()" mode="inline">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+
+    <!-- identity template, drop the rest -->
+    <xsl:template match="@*|*|processing-instruction()|comment()"/>
+</xsl:stylesheet>

--- a/any-to-ssml.xslt
+++ b/any-to-ssml.xslt
@@ -6,8 +6,10 @@
 
     <!-- entry point, look for <article> -->
     <xsl:template match="/">
-        <speak xml:lang="de-DE">
-            <xsl:apply-templates select="//article"/>
+        <speak version="1.0" xml:lang="de-DE">
+            <voice name="de-DE-KatjaNeural">
+                <xsl:apply-templates select="//article"/>
+            </voice>
         </speak>
     </xsl:template>
 


### PR DESCRIPTION
Initial iteration for a simple ssml extraction from news articles.

Example for netzpolitik.org:

```
./any-to-ssml.sh https://netzpolitik.org/2021/netzdg-novelle-mehr-rechte-fuer-nutzerinnen-nur-auf-schmalem-meldeweg/ > ssml.xml
```

Example for republik:
```
./any-to-ssml.sh https://www.republik.ch/2021/05/06/der-glaeserne-gast/ > ssml.xml
```

Example for woz:
```
https://www.woz.ch/2118/auf-allen-kanaelen/auslaendische-agenten > ssml.xml
```

No idea how to crawl bajour.ch. Guess, we need to figure out how to trigger SSR over there.